### PR TITLE
Add triangular head shape

### DIFF
--- a/generate-cat.js
+++ b/generate-cat.js
@@ -40,6 +40,11 @@ var BACKGROUND_COLORS = [
   'white'
 ];
 
+var HEAD_SHAPES = [
+  'ellipse',
+  'triangular'
+];
+
 function cat(canvas, drawControlPoints) {
   var ctx = canvas.getContext('2d');
 
@@ -54,6 +59,8 @@ function cat(canvas, drawControlPoints) {
     height: canvas.height,
     headWidth: _.random(canvas.width * 0.3, canvas.width * 0.4),
     headHeight: _.random(canvas.height * 0.15, canvas.height * 0.275),
+    headShape: _.sample(HEAD_SHAPES),
+    headAngleFactor: _.random(0.75, 0.9),
     centerX: canvas.width / 2,
     centerY: canvas.height / 2,
     earFactorX: _.random(0.9, 1.15),

--- a/lib/head.js
+++ b/lib/head.js
@@ -1,7 +1,35 @@
 'use strict';
 
 module.exports = function (ctx, options) {
-  ctx.ellipse(options.centerX, options.centerY,
-              options.headWidth, options.headHeight,
-              0, 0, 2 * Math.PI);
+  var x = options.centerX;
+  var y = options.centerY;
+  var w = options.headWidth;
+  var h = options.headHeight;
+
+  switch (options.headShape) {
+
+    default:
+    case 'ellipse':
+      ctx.ellipse(x, y,
+                  w, h,
+                  0, 0, 2 * Math.PI);
+      break;
+
+    case 'triangular':
+      ctx.moveTo(x, y - h);
+      ctx.quadraticCurveTo(
+          x - (w * options.headAngleFactor), y - h,
+          x - w, y);
+      ctx.quadraticCurveTo(
+          x - w, y + h,
+          x, y + h);
+      ctx.quadraticCurveTo(
+          x + w, y + h,
+          x + w, y);
+      ctx.quadraticCurveTo(
+          x + (w * options.headAngleFactor), y - h,
+          x, y - h);
+      break;
+
+  }
 };


### PR DESCRIPTION
Adds a second head shape. It's only subtly different, tapering towards the top, but it might be a template for adding more head shapes in future.

![output](https://cloud.githubusercontent.com/assets/14365947/12705835/bb9998f2-c86f-11e5-81e9-e34937c170b9.png)
