### PR TITLE
accessories/glasses 

### DIFF
--- a/lib/accessorize.js
+++ b/lib/accessorize.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var _ = require('lodash');
+
+
+var glasses = require('../parts/glasses')
+var accessories = [glasses]
+
+
+module.exports = function (ctx, options) {
+  // TODO: sometimes apply multiple accessories?
+  var accessory = _.sample(accessories)
+  accessory(ctx, options)
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -63,7 +63,7 @@ module.exports = function (dimension) {
     tabbyFactorY: _.random(0.9, 1.1),
 
     // whiskers
-    droop: Math.random() < 0.5,
+    droop: _.random(0, 1) < 0.5,
     whiskerFactorX: _.random(0.85, 1.01),
     whiskerFactorY: _.random(0.85, 1.01),
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,6 +78,7 @@ module.exports = function (dimension) {
 
   options.mouthWidth = options.headWidth * _.random(0.25, 0.35);
   options.mouthHeight = options.headHeight * _.random(0.15, 0.35);
+  options.eyeSize = options.headWidth * _.random(0.065, 0.08);
 
   return options;
 };

--- a/lib/generate-cat.js
+++ b/lib/generate-cat.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var accessorize = require('./accessorize');
 var background = require('../parts/background.js');
 var bezierTo = require('./bezier-to.js');
 var Canvas = require('canvas-utilities').Canvas;
@@ -45,6 +46,11 @@ module.exports = function (dimension, drawControlPoints) {
 
   if (_.random(0, 100) >= 66) {
     whiskers(ctx, options);
+  }
+
+  // TODO: increase this probability once there are more accessories
+  if (_.random(0, 100) >= 10) {
+    accessorize(ctx, options);
   }
 
   background(ctx, options);

--- a/lib/generate-cat.js
+++ b/lib/generate-cat.js
@@ -49,7 +49,7 @@ module.exports = function (dimension, drawControlPoints) {
   }
 
   // TODO: increase this probability once there are more accessories
-  if (_.random(0, 100) >= 10) {
+  if (_.random(0, 100) >= 90) {
     accessorize(ctx, options);
   }
 

--- a/parts/eyes.js
+++ b/parts/eyes.js
@@ -15,13 +15,11 @@ module.exports = function (ctx, options) {
     ctx.fillStyle = options.eyeColor;
   }
 
-  var eyeSize = options.headWidth * _.random(0.065, 0.08);
-
   // left eye
   ctx.ellipse(-options.headWidth * 0.4,
               options.eyeOffsetY,
-              eyeSize,
-              eyeSize,
+              options.eyeSize,
+              options.eyeSize,
               0, 0, 2 * Math.PI);
 
   ctx.fill();
@@ -31,8 +29,8 @@ module.exports = function (ctx, options) {
   // right eye
   ctx.ellipse(options.headWidth * 0.4,
               options.eyeOffsetY,
-              eyeSize,
-              eyeSize,
+              options.eyeSize,
+              options.eyeSize,
               Math.PI / 2, 0, 2 * Math.PI);
 
   ctx.fillStyle = options.eyeColor;

--- a/parts/glasses.js
+++ b/parts/glasses.js
@@ -19,7 +19,7 @@ module.exports = function (ctx, options) {
 
   // does node have string interps yet? no? ok, fine, TODO make this less awful.
   ctx.fillStyle = "rgba(" + glassesTint[0] + ", " + glassesTint[1] + ", " + glassesTint[2] + ", " + glassesTintLevel + ")";
-  ctx.lineWidth = rimSize;
+  ctx.lineWidth = rimSize * options.scaleFactor;
   ctx.strokeStyle = rimColor;
 
   // left side

--- a/parts/glasses.js
+++ b/parts/glasses.js
@@ -25,14 +25,14 @@ module.exports = function (ctx, options) {
   // left side
   ctx.beginPath();
   ctx.rect(-options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2);
-  ctx.stroke();
   if (isWearingSunglassesAtNight) ctx.fill();
+  ctx.stroke();
 
   // right side
   ctx.beginPath();
   ctx.rect(options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2);
-  ctx.stroke();
   if (isWearingSunglassesAtNight) ctx.fill();
+  ctx.stroke();
 
   // the bridge
   // TODO: sometimes draw a bezier curve from edge of one rect to the other... :<

--- a/parts/glasses.js
+++ b/parts/glasses.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function (ctx, options) {
+  ctx.save()
+  ctx.translate(options.centerX, options.centerY);
+
+  // how far up the glasses the rim should appear
+  var rimDivider = _.random(2, 5)
+  var rimSize = _.random(7, 12)
+  // the radius from center of eye to rim of glasses for each axis
+  var xRad = options.eyeSize * _.random(2.5, 4)
+  var yRad = options.eyeSize * _.random(1.75, 2.5)
+  var glassesColor = _.sample(["#000", "#6617b5", "#b56617", "#1766b5", "#daf650"])
+
+
+  ctx.lineWidth = rimSize
+  ctx.strokeStyle = glassesColor
+
+  ctx.beginPath()
+  ctx.rect(-options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.rect(options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2)
+  ctx.stroke()
+
+  ctx.moveTo(-options.headWidth * 0.4 + xRad, options.eyeOffsetY + yRad / rimDivider)
+  ctx.lineTo(options.headWidth * 0.4 - xRad, options.eyeOffsetY + yRad / rimDivider)
+  ctx.stroke()
+
+
+  // TODO: sometimes draw a bezier curve from edge of one rect to the other... :<
+
+  ctx.restore()
+
+};

--- a/parts/glasses.js
+++ b/parts/glasses.js
@@ -9,29 +9,37 @@ module.exports = function (ctx, options) {
   // how far up the glasses the rim should appear
   var rimDivider = _.random(2, 5)
   var rimSize = _.random(7, 12)
+  var rimColor = _.sample(["#000", "#8B0000", " #A52A2A", "#6617b5", "#b56617", "#1766b5", "#daf650"])
   // the radius from center of eye to rim of glasses for each axis
   var xRad = options.eyeSize * _.random(2.5, 4)
   var yRad = options.eyeSize * _.random(1.75, 2.5)
-  var glassesColor = _.sample(["#000", "#6617b5", "#b56617", "#1766b5", "#daf650"])
+  var isWearingSunglassesAtNight = _.random(0, 1) < 0.5
+  var glassesTintLevel = _.random(0, 0.5)
+  var glassesTint = _.sample([[0, 0, 0], [22, 55, 33], [40, 80, 60], [255, 105, 180], [25, 50, 13], [239, 89, 123], [243, 243, 21], [139, 69, 19], [10, 15, 5]])
 
+  // does node have string interps yet? no? ok, fine, TODO make this less awful.
+  ctx.fillStyle = "rgba(" + glassesTint[0] + ", " + glassesTint[1] + ", " + glassesTint[2] + ", " + glassesTintLevel + ")";
+  ctx.lineWidth = rimSize;
+  ctx.strokeStyle = rimColor;
 
-  ctx.lineWidth = rimSize
-  ctx.strokeStyle = glassesColor
+  // left side
+  ctx.beginPath();
+  ctx.rect(-options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2);
+  ctx.stroke();
+  if (isWearingSunglassesAtNight) ctx.fill();
 
-  ctx.beginPath()
-  ctx.rect(-options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2)
-  ctx.stroke()
+  // right side
+  ctx.beginPath();
+  ctx.rect(options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2);
+  ctx.stroke();
+  if (isWearingSunglassesAtNight) ctx.fill();
 
-  ctx.beginPath()
-  ctx.rect(options.headWidth * 0.4 - xRad, options.eyeOffsetY - yRad, xRad * 2, yRad * 2)
-  ctx.stroke()
-
-  ctx.moveTo(-options.headWidth * 0.4 + xRad, options.eyeOffsetY + yRad / rimDivider)
-  ctx.lineTo(options.headWidth * 0.4 - xRad, options.eyeOffsetY + yRad / rimDivider)
-  ctx.stroke()
-
-
+  // the bridge
   // TODO: sometimes draw a bezier curve from edge of one rect to the other... :<
+  ctx.moveTo(-options.headWidth * 0.4 + xRad, options.eyeOffsetY + yRad / rimDivider);
+  ctx.lineTo(options.headWidth * 0.4 - xRad, options.eyeOffsetY + yRad / rimDivider);
+  ctx.stroke();
+
 
   ctx.restore()
 

--- a/parts/glasses.js
+++ b/parts/glasses.js
@@ -18,7 +18,7 @@ module.exports = function (ctx, options) {
   var glassesTint = _.sample([[0, 0, 0], [22, 55, 33], [40, 80, 60], [255, 105, 180], [25, 50, 13], [239, 89, 123], [243, 243, 21], [139, 69, 19], [10, 15, 5]])
 
   // does node have string interps yet? no? ok, fine, TODO make this less awful.
-  ctx.fillStyle = "rgba(" + glassesTint[0] + ", " + glassesTint[1] + ", " + glassesTint[2] + ", " + glassesTintLevel + ")";
+  ctx.fillStyle = `rgba(${glassesTint[0]}, ${glassesTint[1]}, ${glassesTint[2]}, ${glassesTintLevel})`;
   ctx.lineWidth = rimSize * options.scaleFactor;
   ctx.strokeStyle = rimColor;
 


### PR DESCRIPTION
Adds some basic logic for tossing accessories onto a cat, and glasses too!

accessories can go in `/parts` and just need to be added to the list in `lib/accessorize.js`

some cute lil example boogers:
<img width="264" alt="screen shot 2016-02-02 at 10 57 31 am" src="https://cloud.githubusercontent.com/assets/5067315/12760717/89ffd120-c99c-11e5-8cf5-90082ded2464.png">
<img width="286" alt="screen shot 2016-02-02 at 10 57 24 am" src="https://cloud.githubusercontent.com/assets/5067315/12760715/89fd6a84-c99c-11e5-8e51-2cd96e4d3459.png">
<img width="261" alt="screen shot 2016-02-02 at 10 57 18 am" src="https://cloud.githubusercontent.com/assets/5067315/12760718/8a004eca-c99c-11e5-9823-dd62e2f34f24.png">
<img width="284" alt="screen shot 2016-02-02 at 10 57 10 am" src="https://cloud.githubusercontent.com/assets/5067315/12760716/89fdac56-c99c-11e5-8bd5-c48916eb692e.png">