### PR TITLE
8-bit mode!

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -102,6 +102,10 @@ module.exports = function (dimension) {
     // differing dimensions
     scaleFactor: dimension / 600,
 
+    // 8-bit mode
+    pixelate: _.random(0, 100) >= 95,
+    pixelateResolution: 50,
+
     // to keep track of things that are drawn more than once to get the fill
     // and stroke separately
     usedFunctions: {}

--- a/lib/generate-cat.js
+++ b/lib/generate-cat.js
@@ -12,6 +12,7 @@ var headMask = require('../parts/head-mask.js');
 var headOutline = require('../parts/head-outline.js');
 var mouth = require('../parts/mouth.js');
 var nose = require('../parts/nose.js');
+var pixelate = require('./pixelate');
 var whiskers = require('../parts/whiskers.js');
 
 module.exports = function (dimension, drawControlPoints) {
@@ -60,6 +61,10 @@ module.exports = function (dimension, drawControlPoints) {
     bezierTo.points.forEach(p => controlPoint.apply(null, [ctx].concat(p)));
 
     ctx.restore();
+  }
+
+  if (options.pixelate) {
+    pixelate(canvas, ctx, options.pixelateResolution);
   }
 
   return canvas;

--- a/lib/pixelate.js
+++ b/lib/pixelate.js
@@ -1,0 +1,39 @@
+/**
+ * lib/pixelate.js
+ *
+ * Based on the 8bit package by rogeriopvl (MIT license).
+ * https://www.npmjs.com/package/8bit
+ */
+
+'use strict';
+
+var Canvas = require('canvas-utilities').Canvas;
+
+module.exports = function (canvas, ctx, pxlWidth) {
+  // Step 1: Draw the cat image on a tiny little canvas.
+
+  var pxlHeight = pxlWidth * (canvas.width / canvas.height);
+  var pxlCanvas = new Canvas(pxlWidth, pxlHeight);
+  var pxlCtx = pxlCanvas.getContext('2d');
+
+  var sourceImg = new Canvas.Image();
+  sourceImg.src = canvas.toBuffer();
+  pxlCtx.drawImage(sourceImg, 0, 0, pxlWidth, pxlHeight);
+
+  // Step 2: Draw the tiny image over the original canvas,
+  // stretching the image without smoothing the pixels.
+
+  var pxlBuffer = pxlCanvas.toBuffer();
+
+  ctx.mozImageSmoothingEnabled = false;
+  ctx.webkitImageSmoothingEnabled = false;
+  ctx.imageSmoothingEnabled = false;
+
+  var pxlImg = new Canvas.Image();
+  pxlImg.src = pxlBuffer;
+  ctx.drawImage(pxlImg, 0, 0, canvas.width, canvas.height);
+
+  ctx.mozImageSmoothingEnabled = true;
+  ctx.webkitImageSmoothingEnabled = true;
+  ctx.imageSmoothingEnabled = true;
+};

--- a/lib/pixelate.js
+++ b/lib/pixelate.js
@@ -9,6 +9,10 @@
 
 var Canvas = require('canvas-utilities').Canvas;
 
+function reduceColor(val) {
+  return val - (val % 32);
+}
+
 module.exports = function (canvas, ctx, pxlWidth) {
   // Step 1: Draw the cat image on a tiny little canvas.
 
@@ -20,7 +24,21 @@ module.exports = function (canvas, ctx, pxlWidth) {
   sourceImg.src = canvas.toBuffer();
   pxlCtx.drawImage(sourceImg, 0, 0, pxlWidth, pxlHeight);
 
-  // Step 2: Draw the tiny image over the original canvas,
+  // Step 2: Reduce the colour depth.
+
+  var pxlImageData = pxlCtx.getImageData(0, 0, pxlWidth, pxlHeight);
+  var pixels = pxlImageData.data;
+  var numPixels = pixels.length;
+
+  for (var i = 0; i < numPixels; i++) {
+    pixels[i]     = reduceColor(pixels[i]);
+    pixels[i + 1] = reduceColor(pixels[i + 1]);
+    pixels[i + 2] = reduceColor(pixels[i + 2]);
+  }
+
+  pxlCtx.putImageData(pxlImageData, 0, 0);
+
+  // Step 3: Draw the tiny image over the original canvas,
   // stretching the image without smoothing the pixels.
 
   var pxlBuffer = pxlCanvas.toBuffer();


### PR DESCRIPTION
I made an attempt at 8-bit mode. 5% of the time it draws the cat at a glorious 50x50 pixels. This might need some tweaking – it's configurable in _lib/config.js_.

I borrowed the technique from the [8bit](https://www.npmjs.com/package/8bit) package by rogeriopvl (MIT licensed). It draws the cat image on a tiny tiny canvas, then redraws that tiny image over the original without smoothing the pixels.

![output-grid](https://cloud.githubusercontent.com/assets/14365947/12875924/c4c2c5c0-cdec-11e5-850c-c53400c5ecde.png)